### PR TITLE
Improve projects page layout

### DIFF
--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -1,9 +1,15 @@
 {{ define "main" }}
   <h1>{{ .Title }}</h1>
-  {{ .Content }}
-  <ul>
+  {{ with .Content }}<div class="content">{{ . }}</div>{{ end }}
+  <ul class="project-grid">
     {{ range .Pages }}
-      <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+      <li class="project-card">
+        <a href="{{ .RelPermalink }}">
+          <h2>{{ .Title }}</h2>
+          <img src="{{ .Params.image }}" alt="{{ .Title }} thumbnail">
+          <p>{{ .Params.description }}</p>
+        </a>
+      </li>
     {{ end }}
   </ul>
 {{ end }}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -7,3 +7,23 @@
   display: block;
   margin: 0 auto;
 }
+
+/* Grid layout for projects page */
+.project-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 1rem;
+  list-style: none;
+  padding: 0;
+}
+
+.project-grid .project-card {
+  text-align: center;
+}
+
+.project-grid .project-card img {
+  width: 100%;
+  height: 150px;
+  object-fit: contain;
+  border: 1px solid #ccc;
+}


### PR DESCRIPTION
## Summary
- display projects as grid in list template
- style grid layout and project thumbnails

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844547b3f888326a6bd9db608ee3549