### PR TITLE
Hide contact section on about page

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,4 +1,5 @@
 <!-- layouts/partials/footer.html -->
+{{ if ne .RelPermalink "/about/" }}
 <section id="contact" class="site-contact">
   <h2>{{ with (site.GetPage "contact").Title }}{{ . }}{{ end }}</h2>
   {{ with (site.GetPage "contact").Content }}
@@ -23,3 +24,4 @@
   </form>
   <div id="contact-form-status"></div>
 </section>
+{{ end }}


### PR DESCRIPTION
## Summary
- update footer partial
  - hide contact section if user is on `/about/`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684467a0bd4083269b25b494b7edc56f