### PR TITLE
Add personal profile page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,6 +16,12 @@ theme = "hello-friend-ng"
     weight     = 10
 
   [[menu.main]]
+    identifier = "myself"
+    name       = "Myself"
+    url        = "/myself/"
+    weight     = 15
+
+  [[menu.main]]
     identifier = "projects"
     name       = "Projects"
     url        = "/"

--- a/content/myself.md
+++ b/content/myself.md
@@ -1,0 +1,7 @@
+---
+title: About Myself
+---
+
+![A small profile photo](https://via.placeholder.com/150)
+
+This page is a place where I can share more about who I am and what I'm passionate about.


### PR DESCRIPTION
## Summary
- create simple `/myself` page with profile image
- add navigation link for new page
- include placeholder profile picture

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447411b4d883269838eff7c1aedd0c